### PR TITLE
chore: add dependency-audit workflow and README note

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,36 @@
+name: Dependency audit
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install pip-audit
+        run: python -m pip install --upgrade pip pip-audit
+      - name: Install dependencies (if present)
+        run: |
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt || true
+          else
+            echo "no requirements.txt"
+          fi
+      - name: Run pip-audit
+        run: |
+          pip-audit || true
+      - name: Upload pip-audit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report
+          path: |
+            pip_audit_report.json || true

--- a/README.md
+++ b/README.md
@@ -12,5 +12,26 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 ---
 
+© 2025 GitHub • [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) • [MIT License](https://gh.io/mit)
+
+## Security / Dependency Audit
+
+This repository includes a GitHub Actions workflow that runs `pip-audit` on pushes and pull requests to help detect known vulnerable Python packages. The workflow is located at `.github/workflows/dependency-audit.yml`.
+
+If the audit flags vulnerabilities, please open an issue (or assign this repository's maintainer) to discuss upgrades or replacements.
+# Integrate MCP with Copilot
+
+<img src="https://octodex.github.com/images/Professortocat_v2.png" align="right" height="200px" />
+
+Hey qinxiaobo1988!
+
+Mona here. I'm done preparing your exercise. Hope you enjoy! 💚
+
+Remember, it's self-paced so feel free to take a break! ☕️
+
+[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/qinxiaobo1988/skills-integrate-mcp-with-copilot/issues/1)
+
+---
+
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 


### PR DESCRIPTION
Adds a GitHub Actions workflow to run `pip-audit` on pushes and pull requests and a short README note. This is the first step of the dependency audit/security improvements (see issue #15).